### PR TITLE
Implements multi-site support

### DIFF
--- a/config/statamic/faviconator.php
+++ b/config/statamic/faviconator.php
@@ -3,6 +3,12 @@
 return [
 
 	/**
+	 *	Set a different favicon for each site you have configured.
+	 * 	When enabled it saves the configuration to a file containing the site handle .
+	 */
+	'multi_site' => false,
+
+	/**
 	 * For the purpose of actually providing a image file to generate a favicon from, we need some form of a
 	 * container. If you set container to null, it will grab the first assets container it finds in Statamic
 	 * (usually 'assets', if you haven't changed anything from the template), or else you can set a custom

--- a/src/Http/Controllers/SettingsController.php
+++ b/src/Http/Controllers/SettingsController.php
@@ -2,6 +2,7 @@
 
 namespace Dryven\Faviconator\Http\Controllers;
 
+use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Illuminate\Http\Request;
 use Dryven\Faviconator\Faviconator;
@@ -15,28 +16,20 @@ use Dryven\Faviconator\Configuration\FaviconatorConfig;
  */
 class SettingsController extends CpController
 {
-
-	protected $config;
-
-	public function __construct(Request $request)
-	{
-		parent::__construct($request);
-
-		$this->config = new FaviconatorConfig();
-	}
-
 	public function index()
 	{
 		// No access if the user doesn't have the right permissions to show them
 		abort_unless(User::current()->hasPermission('super') ||
 			User::current()->hasPermission(Faviconator::PERMISSION_GENERAL_KEY), 403);
 
+		$config = $this->getFaviconatorConfig();
+
 		return view(Faviconator::getNamespacedKey('settings'), [
 			'title' => Faviconator::getCpTranslation('title'),
 			'action' => cp_route(Faviconator::ROUTE_SETTINGS_INDEX),
-			'blueprint' => $this->config->blueprint()->toPublishArray(),
-			'values' => $this->config->values(),
-			'meta' => $this->config->fields()->meta()
+			'blueprint' => $config->blueprint()->toPublishArray(),
+			'values' => $config->values(),
+			'meta' => $config->fields()->meta()
 		]);
 	}
 
@@ -46,8 +39,15 @@ class SettingsController extends CpController
 		abort_unless(User::current()->hasPermission('super') ||
 			User::current()->hasPermission(Faviconator::PERMISSION_GENERAL_KEY), 403);
 
-		$values = $this->config->validatedValues($request);
+		$config = $this->getFaviconatorConfig();
 
-		$this->config->setValues($values)->save();
+		$values = $config->validatedValues($request);
+
+		$config->setValues($values)->save();
+	}
+
+	private function getFaviconatorConfig(): FaviconatorConfig
+	{
+		return FaviconatorConfig::create(Site::selected()->handle());
 	}
 }


### PR DESCRIPTION
This PR adds fully BC multi-site support.

It passes the site's handle to the config and saves the config to a file with a suffix of the handle. When the `multi_site` config is set to false it will build the configuration path without suffix to ensure BC.